### PR TITLE
add code cov analysis to analysis.Rmd 

### DIFF
--- a/analysis.Rmd
+++ b/analysis.Rmd
@@ -10,6 +10,8 @@ devtools::install_local(".", force = TRUE, upgrade = "never")
 library(pkgsearchsandbox)
 library(pkgsearch)
 library(ggplot2)
+devtools::install_github("rsquaredacademy/pkginfo")
+library(pkginfo)
 ```
 
 # What do we think is going on with popularity, number of authors, and number of tests?
@@ -48,6 +50,37 @@ ggplot(df, aes(x = author_count, y = downloads_last_month))+
 # TODO: learn more about tests
 
 It would be great to learn things about how many tests are done for the packages. Maybe there is some information in the metadata. If not, could maybe look for this info by looking on github; either in the CRAN mirror, or maybe more appropriately the github repo. This would allows us to look at if testthat is being used; How many tests there are; If codecov is being used and what the code cov is; If any github actions are being used. Perhaps this would give us some idea for ecology packages.
+
+Here, we use get_code_coverage() from the pkginfo package to get code coverage values for individual packages. We are able to get code coverage values for 32 packages. However, the packages that do not have a code coverage value may have tests in the repositories. Now, we will plot code coverage as a function of number of authors, number of downloads last month, and date, respectively. 
+
+```{r echo=FALSE, message=FALSE, warning=FALSE, }
+df$code_cov <- NA
+for (i in 1:nrow(df)) {
+  tryCatch(
+    {
+      df$code_cov[i] <- as.numeric(pkginfo::get_code_coverage(df$package[i]))
+    },
+    error = function(e) {}
+  )
+}
+
+subdf <- subset(df, !is.na(code_cov))
+ggplot(subdf, aes(x = author_count, y = code_cov)) +
+  geom_point() +
+  geom_smooth(method = "lm") +
+  theme_classic()
+
+ggplot(subdf, aes(x = downloads_last_month, y = code_cov)) +
+  geom_point() +
+  geom_smooth(method = "lm") +
+  theme_classic()
+
+ggplot(subdf, aes(x = date, y = code_cov)) +
+  geom_point() +
+  geom_smooth(method = "lm") +
+  theme_classic()
+
+```
 
 # TODO: Is there a better search term besides ecology?
 


### PR DESCRIPTION
This PR addresses issue #2:
- used get_code_coverage() from the pkginfo package to get code coverage values for individual packages
- plotted code coverage as a function of number of authors, number of downloads last month, and date, respectively

Let me know if anything needs to be edited. 